### PR TITLE
Feature/topology node list handling

### DIFF
--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.apache.commons.lang3.math.NumberUtils.max;
+
 /**
  * This class is responsible for executing spatial operations.
  * It uses the SpatialOperation enum to perform the operation and convert the result to the appropriate format.
@@ -36,28 +38,6 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgs) {
-//        List<IOUtility.Output> stream_list = new ArrayList<>();
-//        System.out.println(rawArgs.get(0).size());
-//        System.out.println(rawArgs.get(1).size());
-//
-//        for(int i = 0; i < rawArgs.get(0).size(); i++) {
-//            List<Object> args = new ArrayList<>();
-//            args.add(rawArgs.get(0).get(i));
-//            args.add(rawArgs.get(1).get(i));
-//
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, args));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, args);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                return Stream.empty();
-//            }
-//            Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
-//        }
-//        System.out.println(stream_list.stream());
-//        return stream_list.stream();
-
     public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
         log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
         List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
@@ -67,5 +47,34 @@ public class SpatialOperationExecutor {
             return Stream.empty();
         }
         return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+    }
+
+    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
+        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+
+        List<Object> nList = rawArgsList.get(0);
+        List<Object> mList = rawArgsList.get(1);
+
+        int len = max(nList.size(), mList.size());
+
+        for (int i = 0; i < len; i++) {
+            Object nowN = null;
+            Object nowM = null;
+
+            try {
+                nowN = nList.get(i);
+            } catch (IndexOutOfBoundsException e) {
+                continue;
+            }
+
+            try {
+                nowM = mList.get(i);
+            } catch (IndexOutOfBoundsException e) {
+                continue;
+            }
+
+            List<Object>rawArgs = List.of(nowN, nowM);
+            executeOperation(operationName, rawArgs);
+        }
     }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -5,6 +5,7 @@ import org.neo4j.gspatial.constants.SpatialOperationConstants.SpatialOperation;
 import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -35,6 +36,28 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgs) {
+//        List<IOUtility.Output> stream_list = new ArrayList<>();
+//        System.out.println(rawArgs.get(0).size());
+//        System.out.println(rawArgs.get(1).size());
+//
+//        for(int i = 0; i < rawArgs.get(0).size(); i++) {
+//            List<Object> args = new ArrayList<>();
+//            args.add(rawArgs.get(0).get(i));
+//            args.add(rawArgs.get(1).get(i));
+//
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, args));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, args);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                return Stream.empty();
+//            }
+//            Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        System.out.println(stream_list.stream());
+//        return stream_list.stream();
+
     public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
         log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
         List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -39,8 +39,29 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    //result 가 true일 때의 인덱스를 stream에 담아 반환하는 방법!
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
+        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+        Object result = operation.execute(convertedArgs);
+        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+            return Stream.empty();
+        }
+        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+    }
+
+    /**
+     * Executes the given spatial operation with the given arguments.
+     * The arguments are first converted to the appropriate format using the IOUtility.argsConverter method.
+     * The operation is then performed using the SpatialOperation enum.
+     * If the result of the operation is an empty Geometry, an empty stream is returned.
+     * Otherwise, the result is converted to the appropriate format using the IOUtility.convertResult method and returned as a stream.
+     *
+     * @param operationName the name of the operation to perform
+     * @param rawArgsList the raw arguments for the operation
+     * @return a stream containing the result of the operation
+     */
+    public Stream<IOUtility.Output> executeOperations(String operationName, List<List<Object>> rawArgsList) {
         Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
 
         List<Object> nList = rawArgsList.get(0);
@@ -61,47 +82,4 @@ public class SpatialOperationExecutor {
         }
         return outputBuilder.build();
     }
-
-
-    //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
-//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
-//
-//        List<Object> nList = rawArgsList.get(0);
-//        List<Object> mList = rawArgsList.get(1);
-//
-//        for (int i = 0; i < nList.size(); i++) {
-//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
-//        }
-//        return outputBuilder.build();
-//    }
-
-
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
-//        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//        Object result = operation.execute(convertedArgs);
-//        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//            return Stream.empty();
-//        }
-//        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
-//    }
-//    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-//        List<Object> nList = rawArgsList.get(0);
-//        List<Object> mList = rawArgsList.get(1);
-//
-//        for (int i = 0; i < nList.size(); i++) {
-//            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
-//            executeOperation(operationName, rawArgs);
-//        }
-//    }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -39,16 +39,29 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
-        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-        Object result = operation.execute(convertedArgs);
-        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-            return Stream.empty();
+    //result 가 true일 때의 인덱스를 stream에 담아 반환하는 방법!
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+
+        List<Object> nList = rawArgsList.get(0);
+        List<Object> mList = rawArgsList.get(1);
+
+        for (int i = 0; i < nList.size(); i++) {
+            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+            Object result = operation.execute(convertedArgs);
+            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+                continue;
+            }
+            if (result instanceof Boolean && (Boolean) result) {
+                outputBuilder.add(new IOUtility.Output(i));
+            }
         }
-        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+        return outputBuilder.build();
     }
+
 
     //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
 //    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
@@ -71,35 +84,24 @@ public class SpatialOperationExecutor {
 //        return outputBuilder.build();
 //    }
 
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
-//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
-//
+
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
+//        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//        Object result = operation.execute(convertedArgs);
+//        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//            return Stream.empty();
+//        }
+//        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+//    }
+//    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
 //        List<Object> nList = rawArgsList.get(0);
 //        List<Object> mList = rawArgsList.get(1);
 //
 //        for (int i = 0; i < nList.size(); i++) {
-//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
+//            executeOperation(operationName, rawArgs);
 //        }
-//        return outputBuilder.build();
 //    }
-
-
-
-    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-        List<Object> nList = rawArgsList.get(0);
-        List<Object> mList = rawArgsList.get(1);
-
-        for (int i = 0; i < nList.size(); i++) {
-            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
-            executeOperation(operationName, rawArgs);
-        }
-    }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -6,6 +6,7 @@ import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -49,31 +50,55 @@ public class SpatialOperationExecutor {
         return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
     }
 
-    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+    //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+//
+//        List<Object> nList = rawArgsList.get(0);
+//        List<Object> mList = rawArgsList.get(1);
+//
+//        for (int i = 0; i < nList.size(); i++) {
+//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        return outputBuilder.build();
+//    }
 
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+//
+//        List<Object> nList = rawArgsList.get(0);
+//        List<Object> mList = rawArgsList.get(1);
+//
+//        for (int i = 0; i < nList.size(); i++) {
+//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        return outputBuilder.build();
+//    }
+
+
+
+    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
         List<Object> nList = rawArgsList.get(0);
         List<Object> mList = rawArgsList.get(1);
 
-        int len = max(nList.size(), mList.size());
-
-        for (int i = 0; i < len; i++) {
-            Object nowN = null;
-            Object nowM = null;
-
-            try {
-                nowN = nList.get(i);
-            } catch (IndexOutOfBoundsException e) {
-                continue;
-            }
-
-            try {
-                nowM = mList.get(i);
-            } catch (IndexOutOfBoundsException e) {
-                continue;
-            }
-
-            List<Object>rawArgs = List.of(nowN, nowM);
+        for (int i = 0; i < nList.size(); i++) {
+            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
             executeOperation(operationName, rawArgs);
         }
     }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -41,4 +41,12 @@ public class SpatialProcedures {
         }
         return operationExecutor.executeOperation(operationName, args);
     }
+
+    @Procedure(value = "gspatial.operations")
+    public void operations(@Name("operations") String operationName, @Name("args") List<List<Object>> args) {
+        if (operationExecutor == null) {
+            operationExecutor = new SpatialOperationExecutor(log);
+        }
+        operationExecutor.executeOperations(operationName, args);
+    }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -32,21 +32,21 @@ public class SpatialProcedures {
      * @param args          the arguments for the operation
      * @return a stream containing the result of the operation
      */
+//    @Procedure(value = "gspatial.operation")
+//    @Description("Generic method for spatial operations")
+//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
+//        if (operationExecutor == null) {
+//            operationExecutor = new SpatialOperationExecutor(log);
+//        }
+//        return operationExecutor.executeOperation(operationName, args);
+//    }
+
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
-    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
+    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
         return operationExecutor.executeOperation(operationName, args);
-    }
-
-    @Procedure(value = "gspatial.operations")
-    public void operations(@Name("operations") String operationName, @Name("args") List<List<Object>> args) {
-        if (operationExecutor == null) {
-            operationExecutor = new SpatialOperationExecutor(log);
-        }
-        operationExecutor.executeOperations(operationName, args);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -34,6 +34,7 @@ public class SpatialProcedures {
      */
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
+//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
     public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -32,21 +32,30 @@ public class SpatialProcedures {
      * @param args          the arguments for the operation
      * @return a stream containing the result of the operation
      */
-//    @Procedure(value = "gspatial.operation")
-//    @Description("Generic method for spatial operations")
-//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
-//        if (operationExecutor == null) {
-//            operationExecutor = new SpatialOperationExecutor(log);
-//        }
-//        return operationExecutor.executeOperation(operationName, args);
-//    }
-
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
+    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
         return operationExecutor.executeOperation(operationName, args);
+    }
+
+    /**
+     * Executes the given spatial operation with the given arguments.
+     * The operation is performed using the SpatialOperationExecutor.
+     * The result of the operation is returned as a stream.
+     *
+     * @param operationName the name of the operation to perform
+     * @param argsList      the arguments for the operation
+     * @return a stream containing the result of the operation
+     */
+    @Procedure(value = "gspatial.operations")
+    @Description("Generic method for spatial operations")
+    public Stream<Output> operations(@Name("operations") String operationName, @Name("argsList") List<List<Object>> argsList) {
+        if (operationExecutor == null) {
+            operationExecutor = new SpatialOperationExecutor(log);
+        }
+        return operationExecutor.executeOperations(operationName, argsList);
     }
 }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -89,15 +89,28 @@ public class TestOperationUtility {
          * @return the generated Cypher query
          */
         private String buildSetOperationQuery(String nodeType1, String nodeType2, String operation) {
+            /*
             return String.format(
                     """
                                     MATCH (n:%s)
                                     MATCH (m:%s)
+                                    WITH collect(n) as n_list, collect(m) as m_list
                                     CALL gspatial.operation('intersects', [n.geometry, m.geometry]) YIELD result as intersects_filter
                                     WITH n, m, intersects_filter
                                     WHERE n <> m and intersects_filter = true
                                     CALL gspatial.operation('%s', [n.geometry, m.geometry]) YIELD result
                                     RETURN n.idx, m.idx, result
+                            """,
+                    nodeType1, nodeType2, operation);
+
+             */
+            //변경될 쿼리 -> input 값이 list 형식으로 들어올 것!
+            return String.format(
+                    """
+                            MATCH (n:AgendaArea)
+                            MATCH (m:AgendaArea)
+                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                            CALL gspatial.operation('intersects', [n_list, m_list]) YIELD result
                             """,
                     nodeType1, nodeType2, operation);
         }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -70,12 +70,48 @@ public class TestOperationUtility {
         private String buildOperationQuery(String nodeType1, String nodeType2, String operation, String conditions, String returns) {
             return String.format(
                     """
-                            MATCH (n:%s)
-                            MATCH (m:%s)
-                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operations('%s', [n_list, m_list])
-                          
-                            """,
+                          MATCH (n:%s)
+                          MATCH (m:%s)
+                          WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                                                        
+                          CALL gspatial.operations('%s', [n_list, m_list]) YIELD result
+                                                        
+                          WITH n_list, m_list, result
+                          UNWIND range(0, size(result)-1) AS idx
+                          WITH n_list[idx] AS n, m_list[idx] AS m, result[idx] AS operationResult
+                          WHERE operationResult = true
+                                                   
+                          RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//
+//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+//
+//                            WITH n_list, m_list, [idx IN range(0, size(result)-1) WHERE result[idx] = true | idx] AS trueIndices
+//
+//                            UNWIND trueIndices AS trueIndex
+//                            WITH n_list[trueIndex] AS n, m_list[trueIndex] AS m
+//                            RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+//                            UNWIND result AS operationResult
+//                            WITH n_list[operationResult.idx1] AS n, m_list[operationResult.idx2] AS m
+//                            WHERE n <> m AND operationResult.result = true
+//                            RETURN n.idx, m.idx""",
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//                            CALL gspatial.operations('%s', [n_list, m_list])
+//
+//                            """,
 
 //                    """
 //                            MATCH (n:%s)

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -72,11 +72,19 @@ public class TestOperationUtility {
                     """
                             MATCH (n:%s)
                             MATCH (m:%s)
-                            CALL gspatial.operation('%s', [n, m]) YIELD result
-                            WITH n, m, result
-                            WHERE %s
-                            RETURN %s
+                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+                            RETURN result
                             """,
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            CALL gspatial.operation('%s', [n, m]) YIELD result
+//                            WITH n, m, result
+//                            WHERE %s
+//                            RETURN %s
+//                            """
                     nodeType1, nodeType2, operation, conditions, returns);
         }
 
@@ -89,7 +97,6 @@ public class TestOperationUtility {
          * @return the generated Cypher query
          */
         private String buildSetOperationQuery(String nodeType1, String nodeType2, String operation) {
-            /*
             return String.format(
                     """
                                     MATCH (n:%s)
@@ -100,17 +107,6 @@ public class TestOperationUtility {
                                     WHERE n <> m and intersects_filter = true
                                     CALL gspatial.operation('%s', [n.geometry, m.geometry]) YIELD result
                                     RETURN n.idx, m.idx, result
-                            """,
-                    nodeType1, nodeType2, operation);
-
-             */
-            //변경될 쿼리 -> input 값이 list 형식으로 들어올 것!
-            return String.format(
-                    """
-                            MATCH (n:AgendaArea)
-                            MATCH (m:AgendaArea)
-                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operation('intersects', [n_list, m_list]) YIELD result
                             """,
                     nodeType1, nodeType2, operation);
         }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -73,8 +73,8 @@ public class TestOperationUtility {
                             MATCH (n:%s)
                             MATCH (m:%s)
                             WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-                            RETURN result
+                            CALL gspatial.operations('%s', [n_list, m_list])
+                          
                             """,
 
 //                    """
@@ -84,7 +84,7 @@ public class TestOperationUtility {
 //                            WITH n, m, result
 //                            WHERE %s
 //                            RETURN %s
-//                            """
+//                            """,
                     nodeType1, nodeType2, operation, conditions, returns);
         }
 

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -73,45 +73,14 @@ public class TestOperationUtility {
                           MATCH (n:%s)
                           MATCH (m:%s)
                           WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                                                        
-                          CALL gspatial.operations('%s', [n_list, m_list]) YIELD result
-                                                        
-                          WITH n_list, m_list, result
-                          UNWIND range(0, size(result)-1) AS idx
-                          WITH n_list[idx] AS n, m_list[idx] AS m, result[idx] AS operationResult
-                          WHERE operationResult = true
-                                                   
-                          RETURN n.idx AS nIdx, m.idx AS mIdx;""",
 
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//
-//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-//
-//                            WITH n_list, m_list, [idx IN range(0, size(result)-1) WHERE result[idx] = true | idx] AS trueIndices
-//
-//                            UNWIND trueIndices AS trueIndex
-//                            WITH n_list[trueIndex] AS n, m_list[trueIndex] AS m
-//                            RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+                          CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
 
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-//                            UNWIND result AS operationResult
-//                            WITH n_list[operationResult.idx1] AS n, m_list[operationResult.idx2] AS m
-//                            WHERE n <> m AND operationResult.result = true
-//                            RETURN n.idx, m.idx""",
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//                            CALL gspatial.operations('%s', [n_list, m_list])
-//
-//                            """,
+                          UNWIND result AS idx
+                          WITH n_list[idx] AS n, m_list[idx] AS m
+                          WHERE n <> m
+                          RETURN n.idx, m.idx;
+                          """,
 
 //                    """
 //                            MATCH (n:%s)


### PR DESCRIPTION
## Improvements
Modified the queries for TOPOLOGY operations ("contains", "covers", "covered_by", "crosses", "disjoint", "equals", "intersects", "overlaps", "touches", "within") to handle node lists. Additionally, created a separate function `executeOperations()` to process node lists when received as input.

## Key Code Changes

### buildOperationQuery()
<img src="https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/bf362497-81bb-4ea1-b6f8-920c3c10f17f" width="700px">

Changed the operation format from `gspatial.operation([n, m])` to `gspatial.operation([n_List, m_List])` to perform operations on lists of nodes.

### executeOperations()
<img src="https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/3cba1761-efad-4463-9810-be0144b33ad8" width="700px">

Adjusted the input parameter to receive `rawArgsList` instead of `rawArgs` to allow execution of operations even when input is a list of nodes.

<img src="https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/1eaab23e-3b09-4df1-81f1-80254bc129e8" width="700px">

Notably, instead of returning `result` as a Stream and validating it in the database, the current design validates `result` within `executeOperations()` and returns the indices of true nodes in the given list(`rawArgsList`) as a Stream.
