### PR TITLE
Feature/topology node list handling

### DIFF
--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.apache.commons.lang3.math.NumberUtils.max;
+
 /**
  * This class is responsible for executing spatial operations.
  * It uses the SpatialOperation enum to perform the operation and convert the result to the appropriate format.
@@ -36,28 +38,6 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgs) {
-//        List<IOUtility.Output> stream_list = new ArrayList<>();
-//        System.out.println(rawArgs.get(0).size());
-//        System.out.println(rawArgs.get(1).size());
-//
-//        for(int i = 0; i < rawArgs.get(0).size(); i++) {
-//            List<Object> args = new ArrayList<>();
-//            args.add(rawArgs.get(0).get(i));
-//            args.add(rawArgs.get(1).get(i));
-//
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, args));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, args);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                return Stream.empty();
-//            }
-//            Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
-//        }
-//        System.out.println(stream_list.stream());
-//        return stream_list.stream();
-
     public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
         log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
         List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
@@ -67,5 +47,34 @@ public class SpatialOperationExecutor {
             return Stream.empty();
         }
         return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+    }
+
+    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
+        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+
+        List<Object> nList = rawArgsList.get(0);
+        List<Object> mList = rawArgsList.get(1);
+
+        int len = max(nList.size(), mList.size());
+
+        for (int i = 0; i < len; i++) {
+            Object nowN = null;
+            Object nowM = null;
+
+            try {
+                nowN = nList.get(i);
+            } catch (IndexOutOfBoundsException e) {
+                continue;
+            }
+
+            try {
+                nowM = mList.get(i);
+            } catch (IndexOutOfBoundsException e) {
+                continue;
+            }
+
+            List<Object>rawArgs = List.of(nowN, nowM);
+            executeOperation(operationName, rawArgs);
+        }
     }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -83,11 +83,12 @@ public class SpatialOperationExecutor {
             List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
-            resultList.add(IOUtility.convertResult(result));
 
             if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
                 continue;
             }
+
+            resultList.add(IOUtility.convertResult(result));
 
             if (result instanceof Boolean && (Boolean) result) {
                 indexList.add(IOUtility.convertResult(i));

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -6,7 +6,6 @@ import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -36,36 +35,47 @@ public class SpatialOperationExecutor {
      * Otherwise, the result is converted to the appropriate format using the IOUtility.convertResult method and returned as a stream.
      *
      * @param operationName the name of the operation to perform
-     * @param rawArgs       the raw arguments for the operation
+     * @param rawArgList    the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
-        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-        Object result = operation.execute(convertedArgs);
-        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-            return Stream.empty();
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList) {
+        if (rawArgList.size() == 1) {
+            return executeSingleOperation(operationName, rawArgList.get(0));
         }
-        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+        else {
+            return executeDualOperation(operationName, rawArgList);
+        }
     }
 
-    /**
-     * Executes the given spatial operation with the given arguments.
-     * The arguments are first converted to the appropriate format using the IOUtility.argsConverter method.
-     * The operation is then performed using the SpatialOperation enum.
-     * If the result of the operation is an empty Geometry, an empty stream is returned.
-     * Otherwise, the result is converted to the appropriate format using the IOUtility.convertResult method and returned as a stream.
-     *
-     * @param operationName the name of the operation to perform
-     * @param rawArgsList the raw arguments for the operation
-     * @return a stream containing the result of the operation
-     */
-    public Stream<IOUtility.Output> executeOperations(String operationName, List<List<Object>> rawArgsList) {
-        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs) {
+        List<Object> resultList = new ArrayList<>();
+        List<Object> indexList = new ArrayList<>();
 
-        List<Object> nList = rawArgsList.get(0);
-        List<Object> mList = rawArgsList.get(1);
+        for (int i = 0; i < rawArgs.size(); i++) {
+            List<Object> rawArg = List.of(rawArgs.get(i));
+            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
+            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArg);
+            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+            Object result = operation.execute(convertedArgs);
+            resultList.add(IOUtility.convertResult(result));
+
+            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+                continue;
+            }
+
+            if (result instanceof Boolean && (Boolean) result) {
+                indexList.add(IOUtility.convertResult(i));
+            }
+        }
+        return Stream.of(new IOUtility.Output(resultList, indexList));
+    }
+
+    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList) {
+        List<Object> resultList = new ArrayList<>();
+        List<Object> indexList = new ArrayList<>();
+
+        List<Object> nList = rawArgList.get(0);
+        List<Object> mList = rawArgList.get(1);
 
         for (int i = 0; i < nList.size(); i++) {
             List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
@@ -73,13 +83,17 @@ public class SpatialOperationExecutor {
             List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
+            resultList.add(IOUtility.convertResult(result));
+
             if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
                 continue;
             }
+
             if (result instanceof Boolean && (Boolean) result) {
-                outputBuilder.add(new IOUtility.Output(i));
+                indexList.add(IOUtility.convertResult(i));
             }
         }
-        return outputBuilder.build();
+
+        return Stream.of(new IOUtility.Output(resultList, indexList));
     }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -5,6 +5,7 @@ import org.neo4j.gspatial.constants.SpatialOperationConstants.SpatialOperation;
 import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -35,6 +36,28 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgs) {
+//        List<IOUtility.Output> stream_list = new ArrayList<>();
+//        System.out.println(rawArgs.get(0).size());
+//        System.out.println(rawArgs.get(1).size());
+//
+//        for(int i = 0; i < rawArgs.get(0).size(); i++) {
+//            List<Object> args = new ArrayList<>();
+//            args.add(rawArgs.get(0).get(i));
+//            args.add(rawArgs.get(1).get(i));
+//
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, args));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, args);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                return Stream.empty();
+//            }
+//            Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        System.out.println(stream_list.stream());
+//        return stream_list.stream();
+
     public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
         log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
         List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -39,8 +39,29 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    //result 가 true일 때의 인덱스를 stream에 담아 반환하는 방법!
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
+        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+        Object result = operation.execute(convertedArgs);
+        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+            return Stream.empty();
+        }
+        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+    }
+
+    /**
+     * Executes the given spatial operation with the given arguments.
+     * The arguments are first converted to the appropriate format using the IOUtility.argsConverter method.
+     * The operation is then performed using the SpatialOperation enum.
+     * If the result of the operation is an empty Geometry, an empty stream is returned.
+     * Otherwise, the result is converted to the appropriate format using the IOUtility.convertResult method and returned as a stream.
+     *
+     * @param operationName the name of the operation to perform
+     * @param rawArgsList the raw arguments for the operation
+     * @return a stream containing the result of the operation
+     */
+    public Stream<IOUtility.Output> executeOperations(String operationName, List<List<Object>> rawArgsList) {
         Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
 
         List<Object> nList = rawArgsList.get(0);
@@ -61,47 +82,4 @@ public class SpatialOperationExecutor {
         }
         return outputBuilder.build();
     }
-
-
-    //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
-//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
-//
-//        List<Object> nList = rawArgsList.get(0);
-//        List<Object> mList = rawArgsList.get(1);
-//
-//        for (int i = 0; i < nList.size(); i++) {
-//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
-//        }
-//        return outputBuilder.build();
-//    }
-
-
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
-//        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//        Object result = operation.execute(convertedArgs);
-//        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//            return Stream.empty();
-//        }
-//        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
-//    }
-//    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-//        List<Object> nList = rawArgsList.get(0);
-//        List<Object> mList = rawArgsList.get(1);
-//
-//        for (int i = 0; i < nList.size(); i++) {
-//            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
-//            executeOperation(operationName, rawArgs);
-//        }
-//    }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -39,16 +39,29 @@ public class SpatialOperationExecutor {
      * @param rawArgs       the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
-        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-        Object result = operation.execute(convertedArgs);
-        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-            return Stream.empty();
+    //result 가 true일 때의 인덱스를 stream에 담아 반환하는 방법!
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+
+        List<Object> nList = rawArgsList.get(0);
+        List<Object> mList = rawArgsList.get(1);
+
+        for (int i = 0; i < nList.size(); i++) {
+            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+            Object result = operation.execute(convertedArgs);
+            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+                continue;
+            }
+            if (result instanceof Boolean && (Boolean) result) {
+                outputBuilder.add(new IOUtility.Output(i));
+            }
         }
-        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+        return outputBuilder.build();
     }
+
 
     //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
 //    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
@@ -71,35 +84,24 @@ public class SpatialOperationExecutor {
 //        return outputBuilder.build();
 //    }
 
-//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
-//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
-//
+
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<Object> rawArgs) {
+//        log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//        List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//        SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//        Object result = operation.execute(convertedArgs);
+//        if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//            return Stream.empty();
+//        }
+//        return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
+//    }
+//    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
 //        List<Object> nList = rawArgsList.get(0);
 //        List<Object> mList = rawArgsList.get(1);
 //
 //        for (int i = 0; i < nList.size(); i++) {
-//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
+//            executeOperation(operationName, rawArgs);
 //        }
-//        return outputBuilder.build();
 //    }
-
-
-
-    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-        List<Object> nList = rawArgsList.get(0);
-        List<Object> mList = rawArgsList.get(1);
-
-        for (int i = 0; i < nList.size(); i++) {
-            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
-            executeOperation(operationName, rawArgs);
-        }
-    }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -57,11 +57,12 @@ public class SpatialOperationExecutor {
             List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArg);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
-            resultList.add(IOUtility.convertResult(result));
 
             if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
                 continue;
             }
+
+            resultList.add(IOUtility.convertResult(result));
 
             if (result instanceof Boolean && (Boolean) result) {
                 indexList.add(IOUtility.convertResult(i));

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -6,6 +6,7 @@ import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -49,31 +50,55 @@ public class SpatialOperationExecutor {
         return Stream.of(new IOUtility.Output(IOUtility.convertResult(result)));
     }
 
-    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
-        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+    //거의 된 것 같은데.. 결과 형식이 map을 기대했으나 false가 나왔다고 함!
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+//
+//        List<Object> nList = rawArgsList.get(0);
+//        List<Object> mList = rawArgsList.get(1);
+//
+//        for (int i = 0; i < nList.size(); i++) {
+//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        return outputBuilder.build();
+//    }
 
+//    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgsList) {
+//        Stream.Builder<IOUtility.Output> outputBuilder = Stream.builder();
+//
+//        List<Object> nList = rawArgsList.get(0);
+//        List<Object> mList = rawArgsList.get(1);
+//
+//        for (int i = 0; i < nList.size(); i++) {
+//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
+//            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//            outputBuilder.add(new IOUtility.Output(IOUtility.convertResult(result)));
+//        }
+//        return outputBuilder.build();
+//    }
+
+
+
+    public void executeOperations(String operationName, List<List<Object>> rawArgsList) {
         List<Object> nList = rawArgsList.get(0);
         List<Object> mList = rawArgsList.get(1);
 
-        int len = max(nList.size(), mList.size());
-
-        for (int i = 0; i < len; i++) {
-            Object nowN = null;
-            Object nowM = null;
-
-            try {
-                nowN = nList.get(i);
-            } catch (IndexOutOfBoundsException e) {
-                continue;
-            }
-
-            try {
-                nowM = mList.get(i);
-            } catch (IndexOutOfBoundsException e) {
-                continue;
-            }
-
-            List<Object>rawArgs = List.of(nowN, nowM);
+        for (int i = 0; i < nList.size(); i++) {
+            List<Object>rawArgs = List.of(nList.get(i), mList.get(i));
             executeOperation(operationName, rawArgs);
         }
     }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -2,7 +2,7 @@ package org.neo4j.gspatial.procedures;
 
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.gspatial.functions.SpatialOperationExecutor;
-import org.neo4j.gspatial.utils.IOUtility.Output;
+import org.neo4j.gspatial.utils.IOUtility;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -29,33 +29,15 @@ public class SpatialProcedures {
      * The result of the operation is returned as a stream.
      *
      * @param operationName the name of the operation to perform
-     * @param args          the arguments for the operation
+     * @param argsList      the arguments for the operation
      * @return a stream containing the result of the operation
      */
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
+    public Stream<IOUtility.Output> operation(@Name("operation") String operationName, @Name("argsList") List<List<Object>> argsList) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
-        return operationExecutor.executeOperation(operationName, args);
-    }
-
-    /**
-     * Executes the given spatial operation with the given arguments.
-     * The operation is performed using the SpatialOperationExecutor.
-     * The result of the operation is returned as a stream.
-     *
-     * @param operationName the name of the operation to perform
-     * @param argsList      the arguments for the operation
-     * @return a stream containing the result of the operation
-     */
-    @Procedure(value = "gspatial.operations")
-    @Description("Generic method for spatial operations")
-    public Stream<Output> operations(@Name("operations") String operationName, @Name("argsList") List<List<Object>> argsList) {
-        if (operationExecutor == null) {
-            operationExecutor = new SpatialOperationExecutor(log);
-        }
-        return operationExecutor.executeOperations(operationName, argsList);
+        return operationExecutor.executeOperation(operationName, argsList);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -41,4 +41,12 @@ public class SpatialProcedures {
         }
         return operationExecutor.executeOperation(operationName, args);
     }
+
+    @Procedure(value = "gspatial.operations")
+    public void operations(@Name("operations") String operationName, @Name("args") List<List<Object>> args) {
+        if (operationExecutor == null) {
+            operationExecutor = new SpatialOperationExecutor(log);
+        }
+        operationExecutor.executeOperations(operationName, args);
+    }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -32,21 +32,21 @@ public class SpatialProcedures {
      * @param args          the arguments for the operation
      * @return a stream containing the result of the operation
      */
+//    @Procedure(value = "gspatial.operation")
+//    @Description("Generic method for spatial operations")
+//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
+//        if (operationExecutor == null) {
+//            operationExecutor = new SpatialOperationExecutor(log);
+//        }
+//        return operationExecutor.executeOperation(operationName, args);
+//    }
+
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
-    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
+    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
         return operationExecutor.executeOperation(operationName, args);
-    }
-
-    @Procedure(value = "gspatial.operations")
-    public void operations(@Name("operations") String operationName, @Name("args") List<List<Object>> args) {
-        if (operationExecutor == null) {
-            operationExecutor = new SpatialOperationExecutor(log);
-        }
-        operationExecutor.executeOperations(operationName, args);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -34,6 +34,7 @@ public class SpatialProcedures {
      */
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
+//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
     public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -32,21 +32,30 @@ public class SpatialProcedures {
      * @param args          the arguments for the operation
      * @return a stream containing the result of the operation
      */
-//    @Procedure(value = "gspatial.operation")
-//    @Description("Generic method for spatial operations")
-//    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
-//        if (operationExecutor == null) {
-//            operationExecutor = new SpatialOperationExecutor(log);
-//        }
-//        return operationExecutor.executeOperation(operationName, args);
-//    }
-
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<List<Object>> args) {
+    public Stream<Output> operation(@Name("operation") String operationName, @Name("args") List<Object> args) {
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
         return operationExecutor.executeOperation(operationName, args);
+    }
+
+    /**
+     * Executes the given spatial operation with the given arguments.
+     * The operation is performed using the SpatialOperationExecutor.
+     * The result of the operation is returned as a stream.
+     *
+     * @param operationName the name of the operation to perform
+     * @param argsList      the arguments for the operation
+     * @return a stream containing the result of the operation
+     */
+    @Procedure(value = "gspatial.operations")
+    @Description("Generic method for spatial operations")
+    public Stream<Output> operations(@Name("operations") String operationName, @Name("argsList") List<List<Object>> argsList) {
+        if (operationExecutor == null) {
+            operationExecutor = new SpatialOperationExecutor(log);
+        }
+        return operationExecutor.executeOperations(operationName, argsList);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -81,10 +81,14 @@ public class IOUtility {
      * It includes a single field 'result' that contains the result of the operation.
      */
     public static class Output {
-        public Object result;
+        public List<List<Object>> result;
+        public List<Object> resultList;
+        public List<Object> indexList;
 
-        public Output(Object result) {
-            this.result = result;
+        public Output(List<Object> resultList, List<Object> indexList) {
+            this.resultList = resultList;
+            this.indexList = indexList;
+            this.result = List.of(resultList, indexList);
         }
     }
 }

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class provides utility methods for converting input and output for spatial operations.
+ * This class provides utility methods to convert input and output for spatial operations.
  * It includes methods for converting arguments and results to the appropriate format.
  */
 public class IOUtility {
@@ -30,7 +30,7 @@ public class IOUtility {
     }
 
     /**
-     * Converts the given argument to the appropriate format for spatial operations.
+     * Converts the given argument for spatial operations based on its type.
      * If the argument is a Node, it is converted using the convertNode method.
      * If the argument is a String, it is converted to a Geometry object using the GeometryUtility.parseWKT method.
      * If the argument is a Double and the operation is BUFFER, the argument is returned as is.

--- a/src/test/java/org/neo4j/gspatial/TestIOUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestIOUtility.java
@@ -26,7 +26,7 @@ class CSVResult {
 }
 
 /**
- * This class provides a method for reading a CSV file.
+ * This class provides utility methods for reading a CSV file.
  * It includes a method for reading a CSV file into a CSVResult object.
  */
 class CSVReader {
@@ -79,7 +79,7 @@ class CSVReader {
 }
 
 /**
- * This class provides a method for writing data to a CSV file.
+ * This class provides utility methods for writing data to a CSV file.
  */
 class CSVWriter {
     private static final String RESOURCE_PATH = "src/test/resources";
@@ -116,7 +116,7 @@ class CSVWriter {
 }
 
 /**
- * This class provides a method for loading data into a Neo4j database.
+ * This class provides utility methods for loading data into a Neo4j database.
  */
 class Neo4jLoader {
     /**
@@ -158,7 +158,7 @@ class Neo4jLoader {
 }
 
 /**
- * This class provides a method for converting data.
+ * This class provides utility methods for converting data.
  */
 class DataConverter {
     /**

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -120,7 +120,6 @@ public class TestOperationUtility {
                     """
                                     MATCH (n:%s)
                                     MATCH (m:%s)
-                                    WITH collect(n) as n_list, collect(m) as m_list
                                     CALL gspatial.operation('intersects', [n.geometry, m.geometry]) YIELD result as intersects_filter
                                     WITH n, m, intersects_filter
                                     WHERE n <> m and intersects_filter = true

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -85,7 +85,7 @@ public class TestOperationUtility {
          *
          * @param nodeType1 the type of the first node
          * @param nodeType2 the type of the second node
-         * @param operation the name of the operation
+         * @param operation the name of the set operation
          * @return the generated Cypher query
          */
         private String buildSetOperationQuery(String nodeType1, String nodeType2, String operation) {
@@ -151,7 +151,7 @@ public class TestOperationUtility {
      * Executes the provided Cypher query and returns the results as a list of maps.
      *
      * @param driver      the Neo4j driver
-     * @param cypherQuery the Cypher query to execute
+     * @param cypherQuery the Cypher query to be executed
      * @return a list of maps representing the results of the query
      */
     private static List<Map<String, Object>> executeQuery(Driver driver, String cypherQuery) {

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -89,15 +89,28 @@ public class TestOperationUtility {
          * @return the generated Cypher query
          */
         private String buildSetOperationQuery(String nodeType1, String nodeType2, String operation) {
+            /*
             return String.format(
                     """
                                     MATCH (n:%s)
                                     MATCH (m:%s)
+                                    WITH collect(n) as n_list, collect(m) as m_list
                                     CALL gspatial.operation('intersects', [n.geometry, m.geometry]) YIELD result as intersects_filter
                                     WITH n, m, intersects_filter
                                     WHERE n <> m and intersects_filter = true
                                     CALL gspatial.operation('%s', [n.geometry, m.geometry]) YIELD result
                                     RETURN n.idx, m.idx, result
+                            """,
+                    nodeType1, nodeType2, operation);
+
+             */
+            //변경될 쿼리 -> input 값이 list 형식으로 들어올 것!
+            return String.format(
+                    """
+                            MATCH (n:AgendaArea)
+                            MATCH (m:AgendaArea)
+                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                            CALL gspatial.operation('intersects', [n_list, m_list]) YIELD result
                             """,
                     nodeType1, nodeType2, operation);
         }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -70,12 +70,48 @@ public class TestOperationUtility {
         private String buildOperationQuery(String nodeType1, String nodeType2, String operation, String conditions, String returns) {
             return String.format(
                     """
-                            MATCH (n:%s)
-                            MATCH (m:%s)
-                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operations('%s', [n_list, m_list])
-                          
-                            """,
+                          MATCH (n:%s)
+                          MATCH (m:%s)
+                          WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                                                        
+                          CALL gspatial.operations('%s', [n_list, m_list]) YIELD result
+                                                        
+                          WITH n_list, m_list, result
+                          UNWIND range(0, size(result)-1) AS idx
+                          WITH n_list[idx] AS n, m_list[idx] AS m, result[idx] AS operationResult
+                          WHERE operationResult = true
+                                                   
+                          RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//
+//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+//
+//                            WITH n_list, m_list, [idx IN range(0, size(result)-1) WHERE result[idx] = true | idx] AS trueIndices
+//
+//                            UNWIND trueIndices AS trueIndex
+//                            WITH n_list[trueIndex] AS n, m_list[trueIndex] AS m
+//                            RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+//                            UNWIND result AS operationResult
+//                            WITH n_list[operationResult.idx1] AS n, m_list[operationResult.idx2] AS m
+//                            WHERE n <> m AND operationResult.result = true
+//                            RETURN n.idx, m.idx""",
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+//                            CALL gspatial.operations('%s', [n_list, m_list])
+//
+//                            """,
 
 //                    """
 //                            MATCH (n:%s)

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -72,11 +72,19 @@ public class TestOperationUtility {
                     """
                             MATCH (n:%s)
                             MATCH (m:%s)
-                            CALL gspatial.operation('%s', [n, m]) YIELD result
-                            WITH n, m, result
-                            WHERE %s
-                            RETURN %s
+                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
+                            RETURN result
                             """,
+
+//                    """
+//                            MATCH (n:%s)
+//                            MATCH (m:%s)
+//                            CALL gspatial.operation('%s', [n, m]) YIELD result
+//                            WITH n, m, result
+//                            WHERE %s
+//                            RETURN %s
+//                            """
                     nodeType1, nodeType2, operation, conditions, returns);
         }
 
@@ -89,7 +97,6 @@ public class TestOperationUtility {
          * @return the generated Cypher query
          */
         private String buildSetOperationQuery(String nodeType1, String nodeType2, String operation) {
-            /*
             return String.format(
                     """
                                     MATCH (n:%s)
@@ -100,17 +107,6 @@ public class TestOperationUtility {
                                     WHERE n <> m and intersects_filter = true
                                     CALL gspatial.operation('%s', [n.geometry, m.geometry]) YIELD result
                                     RETURN n.idx, m.idx, result
-                            """,
-                    nodeType1, nodeType2, operation);
-
-             */
-            //변경될 쿼리 -> input 값이 list 형식으로 들어올 것!
-            return String.format(
-                    """
-                            MATCH (n:AgendaArea)
-                            MATCH (m:AgendaArea)
-                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operation('intersects', [n_list, m_list]) YIELD result
                             """,
                     nodeType1, nodeType2, operation);
         }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -120,9 +120,13 @@ public class TestOperationUtility {
                     """
                                     MATCH (n:%s)
                                     MATCH (m:%s)
-                                    CALL gspatial.operation('intersects', [n.geometry, m.geometry]) YIELD result as intersects_filter
-                                    WITH n, m, intersects_filter
-                                    WHERE n <> m and intersects_filter = true
+                                    WITH COLLECT(n) as n_list, COLLECT(m) as m_list
+                                    
+                                    CALL gspatial.operations('intersects', [n_list, m_list]) YIELD result
+                                    
+                                    UNWIND result AS idx
+                                    WITH n_list[idx] AS n, m_list[idx] AS m
+                                    WHERE n <> m
                                     CALL gspatial.operation('%s', [n.geometry, m.geometry]) YIELD result
                                     RETURN n.idx, m.idx, result
                             """,

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -73,8 +73,8 @@ public class TestOperationUtility {
                             MATCH (n:%s)
                             MATCH (m:%s)
                             WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-                            RETURN result
+                            CALL gspatial.operations('%s', [n_list, m_list])
+                          
                             """,
 
 //                    """
@@ -84,7 +84,7 @@ public class TestOperationUtility {
 //                            WITH n, m, result
 //                            WHERE %s
 //                            RETURN %s
-//                            """
+//                            """,
                     nodeType1, nodeType2, operation, conditions, returns);
         }
 

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -73,45 +73,14 @@ public class TestOperationUtility {
                           MATCH (n:%s)
                           MATCH (m:%s)
                           WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-                                                        
-                          CALL gspatial.operations('%s', [n_list, m_list]) YIELD result
-                                                        
-                          WITH n_list, m_list, result
-                          UNWIND range(0, size(result)-1) AS idx
-                          WITH n_list[idx] AS n, m_list[idx] AS m, result[idx] AS operationResult
-                          WHERE operationResult = true
-                                                   
-                          RETURN n.idx AS nIdx, m.idx AS mIdx;""",
 
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//
-//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-//
-//                            WITH n_list, m_list, [idx IN range(0, size(result)-1) WHERE result[idx] = true | idx] AS trueIndices
-//
-//                            UNWIND trueIndices AS trueIndex
-//                            WITH n_list[trueIndex] AS n, m_list[trueIndex] AS m
-//                            RETURN n.idx AS nIdx, m.idx AS mIdx;""",
+                          CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
 
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-//                            UNWIND result AS operationResult
-//                            WITH n_list[operationResult.idx1] AS n, m_list[operationResult.idx2] AS m
-//                            WHERE n <> m AND operationResult.result = true
-//                            RETURN n.idx, m.idx""",
-//                    """
-//                            MATCH (n:%s)
-//                            MATCH (m:%s)
-//                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-//                            CALL gspatial.operations('%s', [n_list, m_list])
-//
-//                            """,
+                          UNWIND result AS idx
+                          WITH n_list[idx] AS n, m_list[idx] AS m
+                          WHERE n <> m
+                          RETURN n.idx, m.idx;
+                          """,
 
 //                    """
 //                            MATCH (n:%s)


### PR DESCRIPTION
## 개선 사항
### 개선 전
기존에는 쿼리문 상에서 `gspatial.operation('operation name', [node1, node2])`와 같은 형식으로 연산을 수행하였다. 이 방식은 공간 데이터 node 별로 연산하여 곧바로 결과가 산출되어 값을 비교하기에 용이하다는 장점이 있었지만 node의 수 만큼 플러그인 내에 있는 함수를 호출해야 한다는 단점도 존재했다.

### 개선 후
이러한 상황에서 공간 데이터 node들을 List화 하여 `gspatial.operation('operation_name', [node_list1, node_list2])`와 같은 형식의 쿼리문을 사용하여 플러그인 내에 있는 함수를 적게 호출할 수 있도록 기능을 개선하였다.

## 핵심 코드 변경 사항
### SpatialProcedures.operation()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/7fd20aee-19d9-4bc3-89fb-1b594c6c52e3)
Neo4j 상에서 `gspatial.operation('operation name', [node_list1, node_list2])` 구문을 실행했을 때 호출되는 부분이다. 이 때 입력 파라미터의 형식 중 argsList의 데이터 타입을 `List<Object>`에서 `List<List<Object>>`로 변경하였다.

### SpatialOperationExecutor.executeOperation()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/8aca6e32-2194-4ee3-ae59-10e31946d135)
입력된 argsList의 크기에 따라 SingleOperation 함수를 실행할지, DualOperation 함수를 실행할지 결정하도록 하였다. centroid, dimension, srid 와 같은 쿼리에는 공간 데이터 node가 하나만 입력된다. 이 경우에는 SingleOperation 함수를 따로 두어 `rawArgList.get(0)` 부분만 입력하여 실행될 수 있도록 구분하였다.

### IOUtility.Output
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/95f5d081-0cdb-4e2e-920a-58a9dfe3a9dc)
플러그인에서 산출한 결과를 Neo4j에 반환할 때의 Output 형식을 지정하는 부분이다. 기존의 방식과 달리 공간 데이터 노드의 리스트를 입력 받아 한 번의 함수 호출로 결과를 반환해야 하기에, Output의 형식 또한 List<List<Object>> 형식으로 변경하였다.

이로써 Neo4j 상에서는 `UNWIND result[0] AS resultList`, `UNWIND result[1] AS indexList` 같은 방식으로 결과를 얻을 수 있다.