### PR TITLE
Feature/wkb processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ To install this plugin into your Neo4j database, follow the steps below:
 
 ## Usage Examples
 To perform spatial operations, you must adhere to the specified format.\
-"CALL gspatial.operation(operationName, [argList1, argList2]) YIELD result"
+`"CALL gspatial.operation(operationName, [argList1, argList2], geomFormat) YIELD result"`
 where operationName is the name of the operation to be performed,
 argList1 and argList2 are the argument lists required for the operation,
+geomFormat is the format of the geometry (WKT or WKB. WKT by default),
 and result is the list consisted with `resultList` and `indexList`.
 `resultList` consists of results of the operation. 
 And `indexList` consists of information about the valid node indices from the results of the operation.
@@ -46,7 +47,7 @@ MATCH (n:NodeType1)
 MATCH (m:NodeType2)
 
 WITH COLLECT(n) as n_list, COLLECT(m) as m_list
-CALL gspatial.operation('CONTAINS', [n_list, m_list]) YIELD result
+CALL gspatial.operation('CONTAINS', [n_list, m_list], 'WKT') YIELD result
 
 UNWIND result[1] AS idx
 WITH n_list[idx] AS n, m_list[idx] AS m
@@ -107,7 +108,7 @@ RETURN n.idx, results
 This query calculates the area of each node of type NodeType1.
 
 ```Cypher
-CALL gspatial.operation('BUFFER', [['POINT (10 10)'], [2.0]]) YIELD result
+CALL gspatial.operation('BUFFER', [['010100000000000000000024400000000000002440'], [2.0]], 'WKB') YIELD result
 UNWIND result[0] AS results
 
 RETURN results;

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -38,23 +38,23 @@ public class SpatialOperationExecutor {
      * @param rawArgList    the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList, String geomType) {
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
         if (rawArgList.size() == 1) {
-            return executeSingleOperation(operationName, rawArgList.get(0), geomType);
+            return executeSingleOperation(operationName, rawArgList.get(0), geomFormat);
         }
         else {
-            return executeDualOperation(operationName, rawArgList, geomType);
+            return executeDualOperation(operationName, rawArgList, geomFormat);
         }
     }
 
-    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomType) {
+    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomFormat) {
         List<Object> resultList = new ArrayList<>();
         List<Object> indexList = new ArrayList<>();
 
         for (int i = 0; i < rawArgs.size(); i++) {
             List<Object> rawArg = List.of(rawArgs.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
-            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomType);
+            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomFormat);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
 
@@ -71,7 +71,7 @@ public class SpatialOperationExecutor {
         return Stream.of(new IOUtility.Output(resultList, indexList));
     }
 
-    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomType) {
+    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
         List<Object> resultList = new ArrayList<>();
         List<Object> indexList = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class SpatialOperationExecutor {
         for (int i = 0; i < nList.size(); i++) {
             List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-            List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomType);
+            List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomFormat);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
 

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -38,23 +38,23 @@ public class SpatialOperationExecutor {
      * @param rawArgList    the raw arguments for the operation
      * @return a stream containing the result of the operation
      */
-    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList) {
+    public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList, String geomType) {
         if (rawArgList.size() == 1) {
-            return executeSingleOperation(operationName, rawArgList.get(0));
+            return executeSingleOperation(operationName, rawArgList.get(0), geomType);
         }
         else {
-            return executeDualOperation(operationName, rawArgList);
+            return executeDualOperation(operationName, rawArgList, geomType);
         }
     }
 
-    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs) {
+    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomType) {
         List<Object> resultList = new ArrayList<>();
         List<Object> indexList = new ArrayList<>();
 
         for (int i = 0; i < rawArgs.size(); i++) {
             List<Object> rawArg = List.of(rawArgs.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
-            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArg);
+            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomType);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
 
@@ -71,7 +71,7 @@ public class SpatialOperationExecutor {
         return Stream.of(new IOUtility.Output(resultList, indexList));
     }
 
-    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList) {
+    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomType) {
         List<Object> resultList = new ArrayList<>();
         List<Object> indexList = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class SpatialOperationExecutor {
         for (int i = 0; i < nList.size(); i++) {
             List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));
-            List<Object> convertedArgs = IOUtility.argsConverter(operationName, rawArgs);
+            List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomType);
             SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
             Object result = operation.execute(convertedArgs);
 

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -34,10 +34,14 @@ public class SpatialProcedures {
      */
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-    public Stream<IOUtility.Output> operation(@Name("operation") String operationName, @Name("argsList") List<List<Object>> argsList) {
+    public Stream<IOUtility.Output> operation(@Name("operation") String operationName, @Name("argsList") List<List<Object>> argsList, @Name(value = "geomType", defaultValue = "WKT") String geomType) {
+        geomType = geomType.toUpperCase();
+        if (!geomType.equals("WKB") && !geomType.equals("WKT")) {
+            throw new IllegalArgumentException("Invalid geomType. Must be either 'WKB' or 'WKT'");
+        }
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
-        return operationExecutor.executeOperation(operationName, argsList);
+        return operationExecutor.executeOperation(operationName, argsList, geomType);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
+++ b/src/main/java/org/neo4j/gspatial/procedures/SpatialProcedures.java
@@ -34,14 +34,14 @@ public class SpatialProcedures {
      */
     @Procedure(value = "gspatial.operation")
     @Description("Generic method for spatial operations")
-    public Stream<IOUtility.Output> operation(@Name("operation") String operationName, @Name("argsList") List<List<Object>> argsList, @Name(value = "geomType", defaultValue = "WKT") String geomType) {
-        geomType = geomType.toUpperCase();
-        if (!geomType.equals("WKB") && !geomType.equals("WKT")) {
-            throw new IllegalArgumentException("Invalid geomType. Must be either 'WKB' or 'WKT'");
+    public Stream<IOUtility.Output> operation(@Name("operation") String operationName, @Name("argsList") List<List<Object>> argsList, @Name(value = "geomFormat", defaultValue = "WKT") String geomFormat) {
+        geomFormat = geomFormat.toUpperCase();
+        if (!geomFormat.equals("WKB") && !geomFormat.equals("WKT")) {
+            throw new IllegalArgumentException("Invalid geomFormat. Must be either 'WKB' or 'WKT'");
         }
         if (operationExecutor == null) {
             operationExecutor = new SpatialOperationExecutor(log);
         }
-        return operationExecutor.executeOperation(operationName, argsList, geomType);
+        return operationExecutor.executeOperation(operationName, argsList, geomFormat);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
@@ -2,6 +2,7 @@ package org.neo4j.gspatial.utils;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
 import org.locationtech.jts.io.WKTReader;
 
 /**
@@ -11,6 +12,7 @@ import org.locationtech.jts.io.WKTReader;
 public class GeometryUtility {
 
     private static final WKTReader wktReader = new WKTReader();
+    private static final WKBReader wkbReader = new WKBReader();
     private static final int defaultSRID = 4326;
 
     /**
@@ -28,6 +30,25 @@ public class GeometryUtility {
             return geometry;
         } catch (ParseException e) {
             throw new IllegalArgumentException("Failed to parse WKT", e);
+        }
+    }
+
+    public static Geometry parseWKB(String wkb) {
+        try {
+            byte[] bytes = WKBReader.hexToBytes(wkb);
+            Geometry geometry = wkbReader.read(bytes);
+            geometry.setSRID(defaultSRID);
+            return geometry;
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Failed to parse WKB", e);
+        }
+    }
+
+    public static Geometry parseGeometry(String data) {
+        try {
+            return parseWKT(data);
+        } catch (IllegalArgumentException e) {
+            return parseWKB(data);
         }
     }
 

--- a/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
@@ -23,7 +23,7 @@ public class GeometryUtility {
      * @return the parsed Geometry object
      * @throws IllegalArgumentException if the WKT string cannot be parsed
      */
-    private static Geometry parseWKT(String wkt) {
+    public static Geometry parseWKT(String wkt) {
         try {
             Geometry geometry = wktReader.read(wkt);
             geometry.setSRID(defaultSRID);
@@ -33,7 +33,7 @@ public class GeometryUtility {
         }
     }
 
-    private static Geometry parseWKB(String wkb) {
+    public static Geometry parseWKB(String wkb) {
         try {
             byte[] bytes = WKBReader.hexToBytes(wkb);
             Geometry geometry = wkbReader.read(bytes);

--- a/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/GeometryUtility.java
@@ -23,7 +23,7 @@ public class GeometryUtility {
      * @return the parsed Geometry object
      * @throws IllegalArgumentException if the WKT string cannot be parsed
      */
-    public static Geometry parseWKT(String wkt) {
+    private static Geometry parseWKT(String wkt) {
         try {
             Geometry geometry = wktReader.read(wkt);
             geometry.setSRID(defaultSRID);
@@ -33,7 +33,7 @@ public class GeometryUtility {
         }
     }
 
-    public static Geometry parseWKB(String wkb) {
+    private static Geometry parseWKB(String wkb) {
         try {
             byte[] bytes = WKBReader.hexToBytes(wkb);
             Geometry geometry = wkbReader.read(bytes);

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -17,14 +17,13 @@ public class IOUtility {
      * Converts the given arguments to the appropriate format for spatial operations.
      * Each argument is converted using the convertArg method.
      *
-     * @param operationName the name of the operation to perform
      * @param args          the arguments for the operation
      * @return the converted arguments
      */
-    public static List<Object> argsConverter(String operationName, List<Object> args) {
+    public static List<Object> argsConverter(List<Object> args, String geomType) {
         List<Object> processedArgs = new ArrayList<>();
         for (Object arg : args) {
-            processedArgs.add(convertArg(arg, operationName));
+            processedArgs.add(convertArg(arg, geomType));
         }
         return processedArgs;
     }
@@ -36,16 +35,19 @@ public class IOUtility {
      * If the argument is a Double and the operation is BUFFER, the argument is returned as is.
      *
      * @param arg           the argument to convert
-     * @param operationName the name of the operation to perform
      * @return the converted argument
      */
-    private static Object convertArg(Object arg, String operationName) {
+    private static Object convertArg(Object arg, String geomType) {
         if (arg instanceof Node) {
-            return convertNode((Node) arg);
-        } else if (arg instanceof String) {
-            return GeometryUtility.parseGeometry((String) arg);
-        } else if (arg instanceof Double && BUFFER_OPERATION.equals(operationName)) {
-            return arg;
+            return convertNode((Node) arg, geomType);
+        }
+        if (arg instanceof String) {
+            if (geomType.equals("WKB")) {
+                return GeometryUtility.parseWKB((String) arg);
+            }
+            if (geomType.equals("WKT")){
+                return GeometryUtility.parseWKT((String) arg);
+            }
         }
         return arg;
     }
@@ -58,9 +60,12 @@ public class IOUtility {
      * @return the converted Geometry object
      * @throws IllegalArgumentException if the Node does not have a 'geometry' property
      */
-    private static Object convertNode(Node node) {
+    private static Object convertNode(Node node, String geomType) {
         if (node.hasProperty("geometry")) {
-            return GeometryUtility.parseGeometry(node.getProperty("geometry").toString());
+            if (geomType.equals("WKB"))
+                return GeometryUtility.parseWKB(node.getProperty("geometry").toString());
+            else if (geomType.equals("WKT"))
+                return GeometryUtility.parseWKT(node.getProperty("geometry").toString());
         }
         throw new IllegalArgumentException("Node does not have a 'geometry' property");
     }

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -20,10 +20,10 @@ public class IOUtility {
      * @param args          the arguments for the operation
      * @return the converted arguments
      */
-    public static List<Object> argsConverter(List<Object> args, String geomType) {
+    public static List<Object> argsConverter(List<Object> args, String geomFormat) {
         List<Object> processedArgs = new ArrayList<>();
         for (Object arg : args) {
-            processedArgs.add(convertArg(arg, geomType));
+            processedArgs.add(convertArg(arg, geomFormat));
         }
         return processedArgs;
     }
@@ -37,15 +37,15 @@ public class IOUtility {
      * @param arg           the argument to convert
      * @return the converted argument
      */
-    private static Object convertArg(Object arg, String geomType) {
+    private static Object convertArg(Object arg, String geomFormat) {
         if (arg instanceof Node) {
-            return convertNode((Node) arg, geomType);
+            return convertNode((Node) arg, geomFormat);
         }
         if (arg instanceof String) {
-            if (geomType.equals("WKB")) {
+            if (geomFormat.equals("WKB")) {
                 return GeometryUtility.parseWKB((String) arg);
             }
-            if (geomType.equals("WKT")){
+            if (geomFormat.equals("WKT")){
                 return GeometryUtility.parseWKT((String) arg);
             }
         }
@@ -60,11 +60,11 @@ public class IOUtility {
      * @return the converted Geometry object
      * @throws IllegalArgumentException if the Node does not have a 'geometry' property
      */
-    private static Object convertNode(Node node, String geomType) {
+    private static Object convertNode(Node node, String geomFormat) {
         if (node.hasProperty("geometry")) {
-            if (geomType.equals("WKB"))
+            if (geomFormat.equals("WKB"))
                 return GeometryUtility.parseWKB(node.getProperty("geometry").toString());
-            else if (geomType.equals("WKT"))
+            else if (geomFormat.equals("WKT"))
                 return GeometryUtility.parseWKT(node.getProperty("geometry").toString());
         }
         throw new IllegalArgumentException("Node does not have a 'geometry' property");

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -60,7 +60,7 @@ public class IOUtility {
      */
     private static Object convertNode(Node node) {
         if (node.hasProperty("geometry")) {
-            return GeometryUtility.parseWKT(node.getProperty("geometry").toString());
+            return GeometryUtility.parseGeometry(node.getProperty("geometry").toString());
         }
         throw new IllegalArgumentException("Node does not have a 'geometry' property");
     }

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -43,7 +43,7 @@ public class IOUtility {
         if (arg instanceof Node) {
             return convertNode((Node) arg);
         } else if (arg instanceof String) {
-            return GeometryUtility.parseWKT((String) arg);
+            return GeometryUtility.parseGeometry((String) arg);
         } else if (arg instanceof Double && BUFFER_OPERATION.equals(operationName)) {
             return arg;
         }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -322,7 +322,7 @@ public class TestOperationUtility {
         if (value instanceof String) {
             String normalizedString = ((String) value).replace("\"", "");
             try {
-                Geometry geometry = GeometryUtility.parseWKT(normalizedString);
+                Geometry geometry = GeometryUtility.parseGeometry(normalizedString);
                 normalizedResult.put("result", geometry);
             } catch (IllegalArgumentException e) {
                 normalizedResult.put("result", normalizedString);


### PR DESCRIPTION
## 개선 사항
### 개선 전
기존에는 `gspatial.operation('operation_name', [node_list1, node_list2])`와 같은 형식의 쿼리문을 사용하였다. 그리고 node_list를 구성하고 있는 각 노드에는 'geometry' 속성이 있었고, 이들은 WKT 포맷으로 저장되어 있었다.

### 개선 후
이번 버전에서는 각 노드에 존재하는 'geometry' 속성에 WKB 포맷 데이터가 존재하더라도, 쿼리를 수행할 수 있도록 개선하였다. 개선된 쿼리문은 다음과 같다.
`gspatial.operation('operation_name', [node_list1, node_list2], 'geomFormat')`

## 핵심 코드 변경 사항
### SpatialProcedures.operation()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/7dcba5f8-56a4-423c-8821-8899d0f99be6)
geomFormat의 Default 값은 'WKT'로 지정하였기에 Neo4j 상에서 쿼리를 수행할 때 geomFormat 파라미터를 입력하지 않으면, 노드 내의 'geometry' 속성이 WKT 포맷으로 저장되었다고 가정하고 연산한다.

### IOUtility.convertArg()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/605b12b2-4d59-4e41-ad2f-bb2efc5b1adb)
입력 파라미터인 geomFormat을 비교하여, WKB 형식이면 `GeometryUtility.parseWKB()`를, WKT 형식이면 `GeometryUtility.parseWKT()`를 호출하도록 설계하였다.

### GeometryUtility.parseWKB()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/1a79065e-1db7-432d-9c2e-93521e3a1843)
기존에 있던 `GeometryUtility.parseWKT()`를 참고하여 새롭게 작성한 코드이다.

---

## Improvement
### Before Improvement
Previously, queries were formulated in the format of `gspatial.operation('operation_name', [node_list1, node_list2])`. Each node in the node list had a 'geometry' attribute, which stored geometry data in WKT format.

### After Improvement
In this version, even if the 'geometry' attribute in each node contains data in WKB format, queries can still be executed. The improved query format is as follows:
`gspatial.operation('operation_name', [node_list1, node_list2], 'geomFormat')`

## Core Code Changes
### SpatialProcedures.operation()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/7dcba5f8-56a4-423c-8821-8899d0f99be6)
The default value for the geomFormat is set to 'WKT'. Therefore, when executing queries in Neo4j without specifying the geomFormat parameter, it is assumed that the 'geometry' property within the node is stored in the Well-Known Text (WKT) format, and operations are performed accordingly.

### IOUtility.convertArg()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/605b12b2-4d59-4e41-ad2f-bb2efc5b1adb)
The design involves comparing the input parameter geomFormat, and if it is in the WKB format, invoking `GeometryUtility.parseWKB()`, and if it is in the WKT format, invoking `GeometryUtility.parseWKT()`.

### GeometryUtility.parseWKB()
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/1a79065e-1db7-432d-9c2e-93521e3a1843)
The code provided is a new implementation inspired by the existing `GeometryUtility.parseWKT()` function.