### PR TITLE
Feature/topology node list handling v2

### DIFF
--- a/src/main/java/org/neo4j/gspatial/constants/SpatialOperationConstants.java
+++ b/src/main/java/org/neo4j/gspatial/constants/SpatialOperationConstants.java
@@ -79,4 +79,9 @@ public final class SpatialOperationConstants {
         return Arrays.asList("CONTAINS", "COVERS", "COVERED_BY", "CROSSES", "DISJOINT", "EQUALS", "INTERSECTS", "OVERLAPS", "TOUCHES", "WITHIN")
                 .contains(operationName.toUpperCase());
     }
+
+    public static boolean isSetOperation(String operationName) {
+        return Arrays.asList("DIFFERENCE", "INTERSECTION", "SYMDIFFERENCE", "UNION")
+                .contains(operationName.toUpperCase());
+    }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -42,74 +42,32 @@ public class SpatialOperationExecutor {
      * @return a stream containing the result of the operation
      */
     public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
-        return executeDualOperation(operationName, rawArgList, geomFormat);
-//        if (rawArgList.size() == 1) {
-//            return executeSingleOperation(operationName, rawArgList.get(0), geomFormat);
-//        }
-//        else {
-//            return executeDualOperation(operationName, rawArgList, geomFormat);
-//        }
+        if (rawArgList.size() == 1) {
+            return executeSingleOperation(operationName, rawArgList.get(0), geomFormat);
+        }
+        else {
+            return executeDualOperation(operationName, rawArgList, geomFormat);
+        }
     }
 
-//    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomFormat) {
-//        List<Object> resultList = new ArrayList<>();
-//        List<Object> indexList = new ArrayList<>();
-//
-//        for (int i = 0; i < rawArgs.size(); i++) {
-//            List<Object> rawArg = List.of(rawArgs.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
-//            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomFormat);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-//            Object result = operation.execute(convertedArgs);
-//
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//
-//            resultList.add(IOUtility.convertResult(result));
-//
-//            if (result instanceof Boolean && (Boolean) result) {
-//                indexList.add(i);
-//            }
-//        }
-//        return Stream.of(new IOUtility.Output(resultList, indexList));
-//    }
+    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomFormat) {
+        List<List<Object>> resultList = new ArrayList<>();
 
-//    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
-//        boolean hasIndexList = false;
-//        List<Object> resultList = new ArrayList<>();
-//        List<Object> indexList = new ArrayList<>();
-//        String operationNameUpper = operationName.toUpperCase();
-//
-//        if (isSetOperation(operationNameUpper)) {
-//            rawArgList = executeIntersectsOperation(rawArgList, geomFormat);
-//            indexList = rawArgList.get(2);
-//            hasIndexList = true;
-//        }
-//
-//        List<Object> nList = rawArgList.get(0);
-//        List<Object> mList = rawArgList.get(1);
-//
-//        for (int i = 0; i < nList.size(); i++) {
-//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
-//            log.info(String.format("Running gspatial.%s with arguments: %s", operationNameUpper, rawArgs));
-//            List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomFormat);
-//            SpatialOperation operation = SpatialOperation.valueOf(operationNameUpper);
-//            Object result = operation.execute(convertedArgs);
-//
-//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-//                continue;
-//            }
-//
-//            resultList.add(IOUtility.convertResult(result));
-//
-//            if (result instanceof Boolean && (Boolean) result && !hasIndexList) {
-//                indexList.add(i);
-//            }
-//        }
-//
-//        return Stream.of(new IOUtility.Output(resultList, indexList));
-//    }
+        for (int i = 0; i < rawArgs.size(); i++) {
+            List<Object> rawArg = List.of(rawArgs.get(i));
+            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
+            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomFormat);
+            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+            Object result = operation.execute(convertedArgs);
+
+            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+                continue;
+            }
+
+            resultList.add(List.of(IOUtility.convertResult(result), rawArg.get(0)));
+        }
+        return Stream.of(new IOUtility.Output(resultList));
+    }
 
     private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
         List<List<Object>> resultList = new ArrayList<>();
@@ -133,9 +91,7 @@ public class SpatialOperationExecutor {
                 continue;
             }
 
-            resultList.add(List.of(nList.get(i), mList.get(i), IOUtility.convertResult(result)));
-
-            //true인 경우에만 하는 작업은 뺐음.. 뭘 했더라?
+            resultList.add(List.of(IOUtility.convertResult(result), nList.get(i), mList.get(i)));
         }
 
         return Stream.of(new IOUtility.Output(resultList));
@@ -144,7 +100,6 @@ public class SpatialOperationExecutor {
     private List<List<Object>> executeIntersectsOperation(List<List<Object>> rawArgList, String geomFormat) {
         List<Object> newNList = new ArrayList<>();
         List<Object> newMList = new ArrayList<>();
-        List<Object> indexList = new ArrayList<>();
 
         List<Object> nList = rawArgList.get(0);
         List<Object> mList = rawArgList.get(1);
@@ -164,10 +119,9 @@ public class SpatialOperationExecutor {
             if (result instanceof Boolean && (Boolean) result) {
                 newNList.add(n);
                 newMList.add(m);
-                indexList.add(i);
             }
         }
 
-        return List.of(newNList, newMList, indexList);
+        return List.of(newNList, newMList);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -119,18 +119,20 @@ public class SpatialOperationExecutor {
         List<Object> mList = rawArgList.get(1);
 
         for (int i = 0; i < nList.size(); i++) {
-            if (nList.get(i).equals(mList.get(i))) {
+            Object n = nList.get(i);
+            Object m = mList.get(i);
+            if (n.equals(m)) {
                 continue;
             }
-            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+            List<Object> rawArgs = List.of(n, m);
             log.info(String.format("Running gspatial.INTERSECTS with arguments: %s", rawArgs));
             List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomFormat);
             SpatialOperation operation = SpatialOperation.INTERSECTS;
             Object result = operation.execute(convertedArgs);
 
             if (result instanceof Boolean && (Boolean) result) {
-                newNList.add(nList.get(i));
-                newMList.add(mList.get(i));
+                newNList.add(n);
+                newMList.add(m);
                 indexList.add(i);
             }
         }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -42,48 +42,81 @@ public class SpatialOperationExecutor {
      * @return a stream containing the result of the operation
      */
     public Stream<IOUtility.Output> executeOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
-        if (rawArgList.size() == 1) {
-            return executeSingleOperation(operationName, rawArgList.get(0), geomFormat);
-        }
-        else {
-            return executeDualOperation(operationName, rawArgList, geomFormat);
-        }
+        return executeDualOperation(operationName, rawArgList, geomFormat);
+//        if (rawArgList.size() == 1) {
+//            return executeSingleOperation(operationName, rawArgList.get(0), geomFormat);
+//        }
+//        else {
+//            return executeDualOperation(operationName, rawArgList, geomFormat);
+//        }
     }
 
-    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomFormat) {
-        List<Object> resultList = new ArrayList<>();
-        List<Object> indexList = new ArrayList<>();
+//    private Stream<IOUtility.Output> executeSingleOperation(String operationName, List<Object> rawArgs, String geomFormat) {
+//        List<Object> resultList = new ArrayList<>();
+//        List<Object> indexList = new ArrayList<>();
+//
+//        for (int i = 0; i < rawArgs.size(); i++) {
+//            List<Object> rawArg = List.of(rawArgs.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
+//            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomFormat);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
+//            Object result = operation.execute(convertedArgs);
+//
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//
+//            resultList.add(IOUtility.convertResult(result));
+//
+//            if (result instanceof Boolean && (Boolean) result) {
+//                indexList.add(i);
+//            }
+//        }
+//        return Stream.of(new IOUtility.Output(resultList, indexList));
+//    }
 
-        for (int i = 0; i < rawArgs.size(); i++) {
-            List<Object> rawArg = List.of(rawArgs.get(i));
-            log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArg));
-            List<Object> convertedArgs = IOUtility.argsConverter(rawArg, geomFormat);
-            SpatialOperation operation = SpatialOperation.valueOf(operationName.toUpperCase());
-            Object result = operation.execute(convertedArgs);
-
-            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
-                continue;
-            }
-
-            resultList.add(IOUtility.convertResult(result));
-
-            if (result instanceof Boolean && (Boolean) result) {
-                indexList.add(i);
-            }
-        }
-        return Stream.of(new IOUtility.Output(resultList, indexList));
-    }
+//    private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
+//        boolean hasIndexList = false;
+//        List<Object> resultList = new ArrayList<>();
+//        List<Object> indexList = new ArrayList<>();
+//        String operationNameUpper = operationName.toUpperCase();
+//
+//        if (isSetOperation(operationNameUpper)) {
+//            rawArgList = executeIntersectsOperation(rawArgList, geomFormat);
+//            indexList = rawArgList.get(2);
+//            hasIndexList = true;
+//        }
+//
+//        List<Object> nList = rawArgList.get(0);
+//        List<Object> mList = rawArgList.get(1);
+//
+//        for (int i = 0; i < nList.size(); i++) {
+//            List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
+//            log.info(String.format("Running gspatial.%s with arguments: %s", operationNameUpper, rawArgs));
+//            List<Object> convertedArgs = IOUtility.argsConverter(rawArgs, geomFormat);
+//            SpatialOperation operation = SpatialOperation.valueOf(operationNameUpper);
+//            Object result = operation.execute(convertedArgs);
+//
+//            if (result instanceof Geometry && ((Geometry) result).isEmpty()) {
+//                continue;
+//            }
+//
+//            resultList.add(IOUtility.convertResult(result));
+//
+//            if (result instanceof Boolean && (Boolean) result && !hasIndexList) {
+//                indexList.add(i);
+//            }
+//        }
+//
+//        return Stream.of(new IOUtility.Output(resultList, indexList));
+//    }
 
     private Stream<IOUtility.Output> executeDualOperation(String operationName, List<List<Object>> rawArgList, String geomFormat) {
-        boolean hasIndexList = false;
-        List<Object> resultList = new ArrayList<>();
-        List<Object> indexList = new ArrayList<>();
+        List<List<Object>> resultList = new ArrayList<>();
         String operationNameUpper = operationName.toUpperCase();
 
         if (isSetOperation(operationNameUpper)) {
             rawArgList = executeIntersectsOperation(rawArgList, geomFormat);
-            indexList = rawArgList.get(2);
-            hasIndexList = true;
         }
 
         List<Object> nList = rawArgList.get(0);
@@ -100,14 +133,12 @@ public class SpatialOperationExecutor {
                 continue;
             }
 
-            resultList.add(IOUtility.convertResult(result));
+            resultList.add(List.of(nList.get(i), mList.get(i), IOUtility.convertResult(result)));
 
-            if (result instanceof Boolean && (Boolean) result && !hasIndexList) {
-                indexList.add(i);
-            }
+            //true인 경우에만 하는 작업은 뺐음.. 뭘 했더라?
         }
 
-        return Stream.of(new IOUtility.Output(resultList, indexList));
+        return Stream.of(new IOUtility.Output(resultList));
     }
 
     private List<List<Object>> executeIntersectsOperation(List<List<Object>> rawArgList, String geomFormat) {

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -84,12 +84,6 @@ public class SpatialOperationExecutor {
         List<Object> nList = rawArgList.get(0);
         List<Object> mList = rawArgList.get(1);
 
-        if (nList.size() < mList.size()) {
-            List<Object> temp = nList;
-            nList = mList;
-            mList = temp;
-        }
-
         for (int i = 0; i < nList.size(); i++) {
             List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationNameUpper, rawArgs));
@@ -112,15 +106,10 @@ public class SpatialOperationExecutor {
     }
 
     private List<List<Object>> executeIntersectsOperation(List<List<Object>> rawArgList, String geomFormat) {
-        List<List<Object>> resultList = new ArrayList<>();
+        List<Object> newNList = new ArrayList<>();
+        List<Object> newMList = new ArrayList<>();
         List<Object> nList = rawArgList.get(0);
         List<Object> mList = rawArgList.get(1);
-
-        if (nList.size() < mList.size()) {
-            List<Object> temp = nList;
-            nList = mList;
-            mList = temp;
-        }
 
         for (int i = 0; i < nList.size(); i++) {
             if (nList.get(i).equals(mList.get(i))) {
@@ -133,10 +122,11 @@ public class SpatialOperationExecutor {
             Object result = operation.execute(convertedArgs);
 
             if (result instanceof Boolean && (Boolean) result) {
-                resultList.add(List.of(nList.get(i), (mList.get(i))));
+                newNList.add(nList.get(i));
+                newMList.add(mList.get(i));
             }
         }
 
-        return resultList;
+        return List.of(newNList, newMList);
     }
 }

--- a/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
+++ b/src/main/java/org/neo4j/gspatial/functions/SpatialOperationExecutor.java
@@ -78,6 +78,12 @@ public class SpatialOperationExecutor {
         List<Object> nList = rawArgList.get(0);
         List<Object> mList = rawArgList.get(1);
 
+        if (nList.size() < mList.size()) {
+            List<Object> temp = nList;
+            nList = mList;
+            mList = temp;
+        }
+
         for (int i = 0; i < nList.size(); i++) {
             List<Object> rawArgs = List.of(nList.get(i), mList.get(i));
             log.info(String.format("Running gspatial.%s with arguments: %s", operationName, rawArgs));

--- a/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
+++ b/src/main/java/org/neo4j/gspatial/utils/IOUtility.java
@@ -85,15 +85,22 @@ public class IOUtility {
      * This class represents the output of a spatial operation.
      * It includes a single field 'result' that contains the result of the operation.
      */
+//    public static class Output {
+//        public List<List<Object>> result;
+//        public List<Object> resultList;
+//        public List<Object> indexList;
+//
+//        public Output(List<Object> resultList, List<Object> indexList) {
+//            this.resultList = resultList;
+//            this.indexList = indexList;
+//            this.result = List.of(resultList, indexList);
+//        }
+//    }
+
     public static class Output {
         public List<List<Object>> result;
-        public List<Object> resultList;
-        public List<Object> indexList;
-
-        public Output(List<Object> resultList, List<Object> indexList) {
-            this.resultList = resultList;
-            this.indexList = indexList;
-            this.result = List.of(resultList, indexList);
+        public Output(List<List<Object>> resultList) {
+            this.result = resultList;
         }
     }
 }

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -129,12 +129,10 @@ public class TestOperationUtility {
                             MATCH (m:%s)
                             WITH COLLECT(n) AS n_list, COLLECT(m) AS m_list
                                                         
-                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result AS results
+                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
                             
-                            
-                            UNWIND results[0] AS result
-                            UNWIND results[1] AS idx
-                            WITH n_list[idx] AS n, m_list[idx] AS m, result
+                            UNWIND result AS res
+                            WITH res[0] AS n, res[1] AS m, res[2] AS result
                                                         
                             RETURN n.idx, m.idx, result
                             """,

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -50,9 +50,9 @@ public class TestOperationUtility {
         public String generateQuery(String nodeType1, String nodeType2, String operation) {
             return switch (this) {
                 case TOPOLOGY ->
-                        buildOperationsQuery(nodeType1, nodeType2, operation, "n <> m", "n.idx, m.idx");
+                        buildOperationsQuery(nodeType1, nodeType2, operation, "n <> m AND result = true", "n.idx, m.idx");
                 case SET -> buildSetOperationQuery(nodeType1, nodeType2, operation);
-                case DUAL_ARG -> buildDistanceOperationQuery(nodeType1, nodeType2, operation, "n <> m", "n.idx, m.idx, result");
+                case DUAL_ARG -> buildOperationsQuery(nodeType1, nodeType2, operation, "n <> m", "n.idx, m.idx, result");
                 case PARAM -> buildParamOperationQuery(nodeType1, nodeType2, operation);
             };
         }
@@ -76,41 +76,12 @@ public class TestOperationUtility {
                            WITH COLLECT(n) as n_list, COLLECT(m) as m_list
                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
                            
-                           UNWIND result[1] AS idx
-                           WITH n_list[idx] AS n, m_list[idx] AS m
+                           UNWIND result AS res
+                           WITH res[1] AS n, res[2] AS m, res[0] AS result
 
                            WHERE %s
                            RETURN %s;
                            """,
-                    nodeType1, nodeType2, operation, conditions, returns);
-        }
-
-
-        /**
-         * Builds a Cypher query for a distance operation.
-         *
-         * @param nodeType1  the type of the first node
-         * @param nodeType2  the type of the second node
-         * @param operation  the name of the operation
-         * @param conditions the conditions for the WHERE clause
-         * @param returns    the expressions for the RETURN clause
-         * @return the generated Cypher query
-         */
-        private String buildDistanceOperationQuery(String nodeType1, String nodeType2, String operation, String conditions, String returns) {
-            return String.format(
-                    """
-                            MATCH (n:%s)
-                            MATCH (m:%s)
-                                                        
-                            WITH n, m, collect(n) AS n_list, collect(m) AS m_list
-                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
-                                                        
-                            UNWIND result[0] AS results
-                            WITH n, m, ROUND(results, 4) AS result
-                            
-                            WHERE %s
-                            RETURN %s
-                            """,
                     nodeType1, nodeType2, operation, conditions, returns);
         }
 
@@ -132,7 +103,7 @@ public class TestOperationUtility {
                             CALL gspatial.operation('%s', [n_list, m_list]) YIELD result
                             
                             UNWIND result AS res
-                            WITH res[0] AS n, res[1] AS m, res[2] AS result
+                            WITH res[1] AS n, res[2] AS m, res[0] AS result
                                                         
                             RETURN n.idx, m.idx, result
                             """,
@@ -154,8 +125,10 @@ public class TestOperationUtility {
                 return String.format(
                         """
                                 MATCH (n:%s)
-                                CALL gspatial.operation('%s', [[n.geometry], [%s]]) YIELD result AS results
-                                UNWIND results[0] AS result
+                                CALL gspatial.operation('%s', [[n.geometry], [%s]]) YIELD result
+                                
+                                UNWIND result AS res
+                                WITH n, res[0] AS result
 
                                 RETURN n.idx, result;
                                 """,
@@ -212,10 +185,12 @@ public class TestOperationUtility {
     private static List<Map<String, Object>> executeSingleInputSpatialQuery(Driver driver, String nodeType, String operation) {
         String cypherQuery = String.format("""
                 MATCH (n:%s)
-                WITH n, collect(n.geometry) AS geometries
-                CALL gspatial.operation('%s', [geometries]) YIELD result AS results
+                WITH COLLECT(n) AS nList
+                CALL gspatial.operation('%s', [nList]) YIELD result
                 
-                UNWIND results[0] AS result
+                UNWIND result AS res
+                WITH res[0] AS result, res[1] AS n
+                
                 RETURN n.idx, result
                 """,
                 nodeType, operation);

--- a/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
+++ b/src/test/java/org/neo4j/gspatial/TestOperationUtility.java
@@ -129,16 +129,12 @@ public class TestOperationUtility {
                             MATCH (m:%s)
                             WITH COLLECT(n) AS n_list, COLLECT(m) AS m_list
                                                         
-                            CALL gspatial.operation('intersects', [n_list, m_list]) YIELD result AS results
-                                                        
-                            UNWIND results[1] AS idx
-                            WITH n_list[idx] AS n, m_list[idx] AS m
-                            WHERE n <> m
-                                                        
-                            WITH n, m, COLLECT(n.geometry) AS geometries1, COLLECT(m.geometry) AS geometries2
-                                                        
-                            CALL gspatial.operation('%s', [geometries1, geometries2]) YIELD result AS results
+                            CALL gspatial.operation('%s', [n_list, m_list]) YIELD result AS results
+                            
+                            
                             UNWIND results[0] AS result
+                            UNWIND results[1] AS idx
+                            WITH n_list[idx] AS n, m_list[idx] AS m, result
                                                         
                             RETURN n.idx, m.idx, result
                             """,


### PR DESCRIPTION
## 개선 사항
### 개선 전
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/a10c2810-2169-443c-9395-1d0bb6ff7fee)
 이전까진 UNION, INTERSECTION 등과 같은 SET 연산을 수행하기 위해서 위와 같이 복잡한 쿼리를 사용하도록 개발했다.

특히 INTERSECTS 연산을 위한 함수를 따로 호출한다는 점, DB에 무리가 되는 UNWIND 작업을 2번이나 수행한다는 점에서 비효율적이었다.

### 개선 후
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/019860f9-876a-4731-9a97-e44241391e22)
 개선된 플러그인에서는 SET 연산의 경우, INTERSECTS 연산을 (내부적으로) Java 코드 상에서 수행하도록 개발하였다. 

그리고 Output의 형태를 바꾸어, UNWIND 작업을 1번만 수행해도 되도록 개발하였다.

![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/67162c3e-71e3-46ca-8ed9-b31396b56410)
각 개선 단계에 따른 결과는 위와 같았다. 1번 그림은 개선하기 전 코드의 결과이다.

2번 그림은 기본 방식에 INTERSECTS 연산을 내부적으로 수행하도록 변경한 결과이다. 이 단계에서는 메모리 사용량에서 성과가 있었다.(약 700만 -> 30만) 그러나 UNWIND 작업을 여러 차례 수행하다보니 DB hits가 14만이나 되었다.

3번 그림은 2번 단계를 적용한 상태에서 Output의 형태를 UNWIND를 1번만 수행해도 되도록 변경한 결과이다. 이 단계에서는 DB hits 관련 결과에서도 성과가 있었다. (약 14만 -> 750) 그래서 최종적으로 메모리 사용량 측면에서도, DB hits 측면에서도 향상된 성능을 보였다.

## 핵심 코드 변경사항
### SpatialOperationExecutor
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/614be753-1bcd-4d89-abce-0ed2d7417948)
연산을 수행할 때 SET 연산인지를 검증하는 내용을 추가했다. 

![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/c886489b-6f86-4e8d-92c0-c8a103310375)
만약 SET 연산이라면, `executeIntersectsOperation()`을 호출하여 연산을 수행한 후, 겹치는 부분이 있는 노드들만 검출하여 리스트로 반환한다.

### IOUtility.Output
![image](https://github.com/GAISLBS/neo4j-gspatial/assets/96401830/bbf12b59-88b5-489f-ac0e-1c57debccfd0)
위 내용은 Output 형태가 기존과 비교하여 어떻게 바뀌었는지 설명하기 위해 간략히 나타낸 것이다. 기존 방식에서는 operation 결과를 모아 놓은 resultList와 operation 결과가 true인 경우에 대한 노드 쌍 차례를 나타내는 indexList로 이루어진 `List<List<Object>> result`를 반환했다.

개선된 방식에서는 operation 결과와 연산에 사용된 Node 자체를 하나의 리스트로 담은 `List<List<Object>> result`를 반환하도록 변경했다. 